### PR TITLE
Add basic authentication and login page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,15 +1,24 @@
 import { useEffect, useState } from 'react';
 import './index.css';
+import Login from './Login';
 
 function App() {
   const [html, setHtml] = useState('');
+  const [token, setToken] = useState(localStorage.getItem('token'));
 
   useEffect(() => {
-    fetch('/dashboard.html')
+    if (!token) return;
+    fetch('/dashboard.html', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
       .then(res => res.text())
       .then(setHtml)
       .catch(err => console.error('Failed to load dashboard', err));
-  }, []);
+  }, [token]);
+
+  if (!token) {
+    return <Login onLogin={setToken} />;
+  }
 
   return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,6 +1,7 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders without crashing', () => {
+test('shows login when no token', () => {
   render(<App />);
+  expect(screen.getByRole('heading', { name: /login/i })).toBeInTheDocument();
 });

--- a/client/src/Login.js
+++ b/client/src/Login.js
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) {
+        setError('Invalid credentials');
+        return;
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      onLogin(data.token);
+    } catch (err) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md w-80">
+        <h2 className="text-2xl mb-4">Login</h2>
+        {error && <p className="text-red-500 mb-2">{error}</p>}
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="border p-2 w-full mb-4"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 w-full mb-4"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded w-full">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,15 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const users = [];
 
 const mongoUri = process.env.MONGODB_URI || 'mongodb://mongo:27017/homeapp';
 if (process.env.NODE_ENV !== 'test') {
@@ -16,12 +21,47 @@ if (process.env.NODE_ENV !== 'test') {
 const ItemSchema = new mongoose.Schema({ name: String });
 const Item = mongoose.model('Item', ItemSchema);
 
-app.get('/api/items', async (req, res) => {
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.sendStatus(401);
+  jwt.verify(token, JWT_SECRET, (err, user) => {
+    if (err) return res.sendStatus(403);
+    req.user = user;
+    next();
+  });
+}
+
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  const existing = users.find(u => u.username === username);
+  if (existing) {
+    return res.status(400).json({ error: 'User exists' });
+  }
+  const passwordHash = await bcrypt.hash(password, 10);
+  users.push({ username, passwordHash });
+  res.status(201).json({ message: 'User registered' });
+});
+
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+app.get('/api/items', authenticateToken, async (req, res) => {
   const items = await Item.find();
   res.json(items);
 });
 
-app.post('/api/items', async (req, res) => {
+app.post('/api/items', authenticateToken, async (req, res) => {
   const item = new Item({ name: req.body.name });
   await item.save();
   res.status(201).json(item);

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -8,3 +8,23 @@ describe('root route', () => {
     expect(res.text).toBe('OK');
   });
 });
+
+describe('authentication', () => {
+  it('registers and logs in a user', async () => {
+    await request(app)
+      .post('/api/register')
+      .send({ username: 'test', password: 'secret' })
+      .expect(201);
+
+    const res = await request(app)
+      .post('/api/login')
+      .send({ username: 'test', password: 'secret' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('blocks access to items without token', async () => {
+    const res = await request(app).get('/api/items');
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -11,8 +11,10 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update node packages
- add JWT-based auth with register/login endpoints and secure item routes
- implement React login page and show dashboard on auth

## Testing
- `cd server && npm test`
- `cd client && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689630f23b848332be5d77e1190ce7f7