### PR TITLE
Add authentication docs and dashboard logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This project converts a static dashboard into a full-stack web application using
    ```
 3. The React client runs on [http://localhost:3000](http://localhost:3000) and the API server on [http://localhost:5000](http://localhost:5000).
 
+### Authentication
+
+Register a user via the `/api/register` endpoint, then log in through the web UI. A JWT is stored in `localStorage` and appended to requests for protected resources. Use the **Logout** button on the dashboard to clear the token.
+
 ## Structure
 
 - `client` – React frontend that loads the dashboard.

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,7 +20,23 @@ function App() {
     return <Login onLogin={setToken} />;
   }
 
-  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+    setHtml('');
+  };
+
+  return (
+    <div>
+      <button
+        onClick={handleLogout}
+        className="absolute top-4 right-4 bg-red-500 text-white px-3 py-1 rounded"
+      >
+        Logout
+      </button>
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- add dashboard logout button to clear stored JWT
- document authentication flow and logout in README

## Testing
- `npm test` (server)
- `CI=true npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_6896344de958833292f69f87584c7dd1