### PR TITLE
Implement functional dashboard with routes and pages

### DIFF
--- a/client/public/app-drawer.html
+++ b/client/public/app-drawer.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>App Drawer</title>
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-gray-100">
+<div class="main-container max-w-xl mx-auto p-4">
+<h1 class="text-2xl font-bold mb-4">App Drawer</h1>
+<form id="itemForm" class="mb-4 flex">
+<input id="name" class="border flex-grow px-2 py-1" placeholder="Item name" />
+<button class="bg-blue-500 text-white px-3 py-1 ml-2 rounded" type="submit">Add</button>
+</form>
+<ul id="items" class="list-disc pl-5"></ul>
+<a href="/dashboard.html" data-nav class="text-blue-500 underline block mt-4">Back to Dashboard</a>
+</div>
+<script>
+async function loadItems(){
+  const token = localStorage.getItem('token');
+  const res = await fetch('/api/items',{headers:{Authorization:'Bearer '+token}});
+  const items = await res.json();
+  const list = document.getElementById('items');
+  list.innerHTML='';
+  items.forEach(i=>{const li=document.createElement('li');li.textContent=i.name;list.appendChild(li);});
+}
+async function addItem(e){
+  e.preventDefault();
+  const name=document.getElementById('name').value.trim();
+  if(!name) return;
+  const token=localStorage.getItem('token');
+  await fetch('/api/items',{method:'POST',headers:{'Content-Type':'application/json',Authorization:'Bearer '+token},body:JSON.stringify({name})});
+  document.getElementById('name').value='';
+  loadItems();
+}
+const form=document.getElementById('itemForm');
+form.addEventListener('submit',addItem);
+loadItems();
+</script>
+</body></html>

--- a/client/public/dashboard.html
+++ b/client/public/dashboard.html
@@ -40,30 +40,30 @@
 <p class="text-xs mt-4">Updated at 8:57 AM <span class="material-icons text-xs">refresh</span></p>
 </div>
 <div class="grid grid-cols-2 gap-4">
-<div class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
+<a href="/app-drawer.html" data-nav class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
 <div class="bg-blue-100 p-3 rounded-full">
 <span class="material-icons text-blue-500">apps</span>
 </div>
 <p class="text-sm mt-2">App Drawer</p>
-</div>
-<div class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
+</a>
+<a href="/screen-saver.html" data-nav class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
 <div class="bg-blue-100 p-3 rounded-full">
 <span class="material-icons text-blue-500">desktop_windows</span>
 </div>
 <p class="text-sm mt-2">Screen Saver</p>
-</div>
-<div class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
+</a>
+<a href="/help.html" data-nav class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
 <div class="bg-blue-100 p-3 rounded-full">
 <span class="material-icons text-blue-500">help_outline</span>
 </div>
 <p class="text-sm mt-2">Help &amp; Support</p>
-</div>
-<div class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
+</a>
+<a href="#" data-logout class="bg-white p-4 rounded-2xl flex flex-col items-center justify-center text-center">
 <div class="bg-blue-100 p-3 rounded-full">
 <span class="material-icons text-blue-500">lock</span>
 </div>
 <p class="text-sm mt-2">Lock</p>
-</div>
+</a>
 </div>
 </div>
 <div class="bg-white p-6 rounded-3xl">

--- a/client/public/help.html
+++ b/client/public/help.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Help & Support</title>
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-gray-100">
+<div class="main-container max-w-xl mx-auto p-4">
+<h1 class="text-2xl font-bold mb-4">Help & Support</h1>
+<p>If you need assistance, contact <a class="text-blue-500 underline" href="mailto:support@example.com">support@example.com</a>.</p>
+<a href="/dashboard.html" data-nav class="text-blue-500 underline block mt-4">Back to Dashboard</a>
+</div>
+</body></html>

--- a/client/public/screen-saver.html
+++ b/client/public/screen-saver.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Screen Saver</title>
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-black text-white flex items-center justify-center h-screen">
+<div class="text-center">
+<p class="mb-4">Screen Saver</p>
+<a href="/dashboard.html" data-nav class="underline">Back to Dashboard</a>
+</div>
+</body></html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import './index.css';
 import Login from './Login';
 import Register from './Register';
@@ -7,16 +7,50 @@ function App() {
   const [html, setHtml] = useState('');
   const [token, setToken] = useState(localStorage.getItem('token'));
   const [showRegister, setShowRegister] = useState(false);
+  const containerRef = useRef(null);
+
+  const loadPage = (url) => {
+    fetch(url, { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => res.text())
+      .then(text => {
+        setHtml(text);
+        setTimeout(() => {
+          const scripts = containerRef.current?.querySelectorAll('script') || [];
+          scripts.forEach(script => {
+            try {
+              // eslint-disable-next-line no-eval
+              eval(script.textContent);
+            } catch (e) {
+              console.error('Error executing script', e);
+            }
+          });
+        }, 0);
+      })
+      .catch(err => console.error('Failed to load page', err));
+  };
 
   useEffect(() => {
     if (!token) return;
-    fetch('/dashboard.html', {
-      headers: { Authorization: `Bearer ${token}` }
-    })
-      .then(res => res.text())
-      .then(setHtml)
-      .catch(err => console.error('Failed to load dashboard', err));
+    loadPage('/dashboard.html');
   }, [token]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const anchor = e.target.closest('a');
+      if (!anchor) return;
+      if (anchor.dataset.nav !== undefined) {
+        e.preventDefault();
+        loadPage(anchor.getAttribute('href'));
+      }
+      if (anchor.dataset.logout !== undefined) {
+        e.preventDefault();
+        handleLogout();
+      }
+    };
+    const current = containerRef.current;
+    current?.addEventListener('click', handler);
+    return () => current?.removeEventListener('click', handler);
+  }, [token, html]);
 
     if (!token) {
       if (showRegister) {
@@ -44,7 +78,7 @@ function App() {
       >
         Logout
       </button>
-      <div dangerouslySetInnerHTML={{ __html: html }} />
+      <div ref={containerRef} dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const path = require('path');
 
 const app = express();
 app.use(cors());
@@ -65,6 +66,22 @@ app.post('/api/items', authenticateToken, async (req, res) => {
   const item = new Item({ name: req.body.name });
   await item.save();
   res.status(201).json(item);
+});
+
+app.get('/dashboard.html', authenticateToken, (req, res) => {
+  res.sendFile(path.join(__dirname, '../client/public/dashboard.html'));
+});
+
+app.get('/app-drawer.html', authenticateToken, (req, res) => {
+  res.sendFile(path.join(__dirname, '../client/public/app-drawer.html'));
+});
+
+app.get('/screen-saver.html', authenticateToken, (req, res) => {
+  res.sendFile(path.join(__dirname, '../client/public/screen-saver.html'));
+});
+
+app.get('/help.html', authenticateToken, (req, res) => {
+  res.sendFile(path.join(__dirname, '../client/public/help.html'));
 });
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- Add client-side navigation loader to fetch authenticated HTML pages and execute embedded scripts
- Turn dashboard buttons into navigable links and add App Drawer, Screen Saver, and Help pages
- Serve new dashboard-related HTML files behind auth on the server

## Testing
- `cd client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689697c0c2988332a23cad4624672380